### PR TITLE
Use Euclidean distance only in a color space meant for it.

### DIFF
--- a/lib/src/main/java/de/pottgames/lesscolors/Color.java
+++ b/lib/src/main/java/de/pottgames/lesscolors/Color.java
@@ -16,7 +16,9 @@
 
 package de.pottgames.lesscolors;
 
-import java.util.Objects;
+import com.github.ajalt.colormath.model.LAB;
+import com.github.ajalt.colormath.model.Oklab;
+import com.github.ajalt.colormath.model.RGB;
 
 /**
  * Represents a color with components and color space information.
@@ -168,20 +170,36 @@ public class Color {
         return b | g << 8 | r << 16 | a << 24;
     }
 
-
     /**
      * Calculates the LAB color distance between this color and another color.
      *
      * @param other The other color.
-     * @return The LAB color distance between the two colors.
+     * @return The LAB color distance between the two colors, using the CIE2000 difference metric.
      */
     public float labDistance(Color other) {
-        Color comp1 = this.colorSpace == ColorSpace.LAB ? this : this.toLab();
-        Color comp2 = other.colorSpace == ColorSpace.LAB ? other : other.toLab();
-        double lSquare = Math.pow(comp1.component1 - comp2.component1, 2d);
-        double aSquare = Math.pow(comp1.component2 - comp2.component2, 2d);
-        double bSquare = Math.pow(comp1.component3 - comp2.component3, 2d);
-        return (float) Math.sqrt(lSquare + aSquare + bSquare);
+        com.github.ajalt.colormath.Color comp1 = this.colorSpace == ColorSpace.LAB
+                ? LAB.Companion.invoke(this.component1, this.component2, this.component3, this.component4)
+                : RGB.Companion.invoke(this.component1, this.component2, this.component3, this.component4);
+        com.github.ajalt.colormath.Color comp2 = other.colorSpace == ColorSpace.LAB
+                ? LAB.Companion.invoke(other.component1, other.component2, other.component3, other.component4)
+                : RGB.Companion.invoke(other.component1, other.component2, other.component3, other.component4);
+        return com.github.ajalt.colormath.calculate.DifferenceKt.differenceCIE2000(comp1, comp2);
+    }
+
+    /**
+     * Calculates the Oklab color distance between this color and another color.
+     *
+     * @param other The other color.
+     * @return The Oklab color distance between the two colors, using Euclidean distance in Oklab space.
+     */
+    public float oklabDistance(Color other) {
+        Oklab comp1 = this.colorSpace == ColorSpace.LAB
+                ? LAB.Companion.invoke(this.component1, this.component2, this.component3, this.component4).toOklab()
+                : RGB.Companion.invoke(this.component1, this.component2, this.component3, this.component4).toOklab();
+        Oklab comp2 = other.colorSpace == ColorSpace.LAB
+                ? LAB.Companion.invoke(other.component1, other.component2, other.component3, other.component4).toOklab()
+                : RGB.Companion.invoke(other.component1, other.component2, other.component3, other.component4).toOklab();
+        return com.github.ajalt.colormath.calculate.DifferenceKt.euclideanDistance(comp1, comp2);
     }
 
 
@@ -214,18 +232,28 @@ public class Color {
                Float.compare(component3, color.component3) == 0 && Float.compare(component4, color.component4) == 0 &&
                colorSpace == color.colorSpace;
     }
-
-
     /**
-     * Generates a hash code for this color object.
+     * Generates a hash code for this Color object.
      *
      * @return The hash code.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(component1, component2, component3, component4, colorSpace);
+        int result = (component1 != 0.0f ? Float.floatToIntBits(component1) : 0);
+        result = 31 * result + (component2 != 0.0f ? Float.floatToIntBits(component2) : 0);
+        result = 31 * result + (component3 != 0.0f ? Float.floatToIntBits(component3) : 0);
+        result = 31 * result + (component4 != 0.0f ? Float.floatToIntBits(component4) : 0);
+        result = 31 * result + (colorSpace != null ? colorSpace.hashCode() : 0);
+        return result;
     }
 
+    @Override
+    public String toString() {
+        if (colorSpace == ColorSpace.LAB) {
+            return "Color {L=" + component1 + ", A=" + component2 + ", B=" + component3 + ", Alpha=" + component4 + "}";
+        }
+        return "Color {Red=" + component1 + ", Green=" + component2 + ", Blue=" + component3 + ", Alpha=" + component4 + "}";
+    }
 
     /**
      * Enumeration of supported color spaces.

--- a/lib/src/main/java/de/pottgames/lesscolors/Color.java
+++ b/lib/src/main/java/de/pottgames/lesscolors/Color.java
@@ -16,6 +16,7 @@
 
 package de.pottgames.lesscolors;
 
+import com.github.ajalt.colormath.calculate.DifferenceKt;
 import com.github.ajalt.colormath.model.LAB;
 import com.github.ajalt.colormath.model.Oklab;
 import com.github.ajalt.colormath.model.RGB;
@@ -170,6 +171,7 @@ public class Color {
         return b | g << 8 | r << 16 | a << 24;
     }
 
+
     /**
      * Calculates the LAB color distance between this color and another color.
      *
@@ -177,14 +179,15 @@ public class Color {
      * @return The LAB color distance between the two colors, using the CIE2000 difference metric.
      */
     public float labDistance(Color other) {
-        com.github.ajalt.colormath.Color comp1 = this.colorSpace == ColorSpace.LAB
-                ? LAB.Companion.invoke(this.component1, this.component2, this.component3, this.component4)
-                : RGB.Companion.invoke(this.component1, this.component2, this.component3, this.component4);
-        com.github.ajalt.colormath.Color comp2 = other.colorSpace == ColorSpace.LAB
-                ? LAB.Companion.invoke(other.component1, other.component2, other.component3, other.component4)
-                : RGB.Companion.invoke(other.component1, other.component2, other.component3, other.component4);
-        return com.github.ajalt.colormath.calculate.DifferenceKt.differenceCIE2000(comp1, comp2);
+        com.github.ajalt.colormath.Color comp1 = this.colorSpace == ColorSpace.LAB ?
+                LAB.Companion.invoke(this.component1, this.component2, this.component3, this.component4) :
+                RGB.Companion.invoke(this.component1, this.component2, this.component3, this.component4);
+        com.github.ajalt.colormath.Color comp2 = other.colorSpace == ColorSpace.LAB ?
+                LAB.Companion.invoke(other.component1, other.component2, other.component3, other.component4) :
+                RGB.Companion.invoke(other.component1, other.component2, other.component3, other.component4);
+        return DifferenceKt.differenceCIE2000(comp1, comp2);
     }
+
 
     /**
      * Calculates the Oklab color distance between this color and another color.
@@ -193,13 +196,13 @@ public class Color {
      * @return The Oklab color distance between the two colors, using Euclidean distance in Oklab space.
      */
     public float oklabDistance(Color other) {
-        Oklab comp1 = this.colorSpace == ColorSpace.LAB
-                ? LAB.Companion.invoke(this.component1, this.component2, this.component3, this.component4).toOklab()
-                : RGB.Companion.invoke(this.component1, this.component2, this.component3, this.component4).toOklab();
-        Oklab comp2 = other.colorSpace == ColorSpace.LAB
-                ? LAB.Companion.invoke(other.component1, other.component2, other.component3, other.component4).toOklab()
-                : RGB.Companion.invoke(other.component1, other.component2, other.component3, other.component4).toOklab();
-        return com.github.ajalt.colormath.calculate.DifferenceKt.euclideanDistance(comp1, comp2);
+        Oklab comp1 = this.colorSpace == ColorSpace.LAB ?
+                LAB.Companion.invoke(this.component1, this.component2, this.component3, this.component4).toOklab() :
+                RGB.Companion.invoke(this.component1, this.component2, this.component3, this.component4).toOklab();
+        Oklab comp2 = other.colorSpace == ColorSpace.LAB ?
+                LAB.Companion.invoke(other.component1, other.component2, other.component3, other.component4).toOklab() :
+                RGB.Companion.invoke(other.component1, other.component2, other.component3, other.component4).toOklab();
+        return DifferenceKt.euclideanDistance(comp1, comp2);
     }
 
 
@@ -232,6 +235,8 @@ public class Color {
                Float.compare(component3, color.component3) == 0 && Float.compare(component4, color.component4) == 0 &&
                colorSpace == color.colorSpace;
     }
+
+
     /**
      * Generates a hash code for this Color object.
      *
@@ -239,21 +244,29 @@ public class Color {
      */
     @Override
     public int hashCode() {
-        int result = (component1 != 0.0f ? Float.floatToIntBits(component1) : 0);
-        result = 31 * result + (component2 != 0.0f ? Float.floatToIntBits(component2) : 0);
-        result = 31 * result + (component3 != 0.0f ? Float.floatToIntBits(component3) : 0);
-        result = 31 * result + (component4 != 0.0f ? Float.floatToIntBits(component4) : 0);
+        int result = (component1 != 0f ? Float.floatToIntBits(component1) : 0);
+        result = 31 * result + (component2 != 0f ? Float.floatToIntBits(component2) : 0);
+        result = 31 * result + (component3 != 0f ? Float.floatToIntBits(component3) : 0);
+        result = 31 * result + (component4 != 0f ? Float.floatToIntBits(component4) : 0);
         result = 31 * result + (colorSpace != null ? colorSpace.hashCode() : 0);
         return result;
     }
 
+
     @Override
     public String toString() {
-        if (colorSpace == ColorSpace.LAB) {
-            return "Color {L=" + component1 + ", A=" + component2 + ", B=" + component3 + ", Alpha=" + component4 + "}";
+        switch (this.colorSpace) {
+            case LAB:
+                return "Color {L=" + component1 + ", A=" + component2 + ", B=" + component3 + ", Alpha=" + component4 +
+                       "}";
+            case RGB:
+                return "Color {Red=" + component1 + ", Green=" + component2 + ", Blue=" + component3 + ", Alpha=" +
+                       component4 + "}";
+            default:
+                return "Color {invalid colorspace}";
         }
-        return "Color {Red=" + component1 + ", Green=" + component2 + ", Blue=" + component3 + ", Alpha=" + component4 + "}";
     }
+
 
     /**
      * Enumeration of supported color spaces.

--- a/lib/src/main/java/de/pottgames/lesscolors/ColorPalette.java
+++ b/lib/src/main/java/de/pottgames/lesscolors/ColorPalette.java
@@ -71,7 +71,7 @@ public class ColorPalette implements Iterable<Color> {
         float closestDistance = Float.MAX_VALUE;
 
         for (Color color : this.colors) {
-            float distance = color.labDistance(other);
+            float distance = color.oklabDistance(other);
             if (distance < closestDistance) {
                 closestDistance = distance;
                 closestColor = color;


### PR DESCRIPTION
RGB, whether linear or nonlinear, isn't a good fit for a Euclidean distance metric to compare colors. It seems like LAB isn't either, based on my limited experiments with the code here. I use Oklab at almost every opportunity I get, and it is meant to be closer to perceptually uniform than other color spaces that are often much more complex. That means all we need with the Oklab color space is a Euclidean distance, nothing crazy like CIE2000 (as is suggested sometimes for LAB colors). What's more, the colormath library you already use provides methods to convert to Oklab (or any of many other color spaces). I also tried JzAzBz, but encountered a really strange NPE when I tried to convert a  jpg of the famous painting "Girl with a Pearl Earring". I don't know what about that file was trouble, but that should probably not be happening.

This also supplies a method to get the CIE2000 difference between LAB colors, but doesn't currently use it. The results with Oklab generally seem much better.

Original image:
![Mona_Lisa](https://github.com/Hangman/lesscolors/assets/160684/b6be7c56-d3de-4335-86f0-319d77a5a961)

Without PR, using LAB and Euclidean distance:
![MonaLisaLABEuclidean](https://github.com/Hangman/lesscolors/assets/160684/94996f5f-be51-4f2c-b8a7-00dd1d567599)

With this PR, Using Oklab and Euclidean distance:
![MonaLisaOklabEuclidean](https://github.com/Hangman/lesscolors/assets/160684/9573e038-9ab1-4180-97ce-37e8f593c985)

If you're interested in contributing to an existing project, then [anim8-gdx](https://github.com/tommyettinger/anim8-gdx) might benefit from some feature suggestions -- I already implemented the feature from this app where it can pull a palette from an image, though in my case it doesn't need to iterate over every pixel in the palette for every pixel in the input image, since it assembles an array of the most frequent 255 colors encountered, plus fully-transparent.